### PR TITLE
core.py: Fix bug due to Python Doctest

### DIFF
--- a/ramlient/core.py
+++ b/ramlient/core.py
@@ -127,6 +127,10 @@ class Client(object):
         """
             Access ResourceNode from RAML
         """
+        # Workaround for python doctest
+        if attr == '__wrapped__':
+            return False
+
         resource = self.get_resource("/", attr)
         if not resource:
             raise ResourceNotFoundError(attr)


### PR DESCRIPTION
`doctest.DocTestFinder().find()` was raising
unexpected `ResourceNotFoundError` exception
due to upstream changes in Python 3.5

Fixes https://github.com/timofurrer/ramlient/issues/51